### PR TITLE
Fix: #37. Support asset/ folders.

### DIFF
--- a/src/main/java/it/gov/innovazione/ndc/harvester/AgencyRepositoryService.java
+++ b/src/main/java/it/gov/innovazione/ndc/harvester/AgencyRepositoryService.java
@@ -64,7 +64,11 @@ public class AgencyRepositoryService {
         Path assetRootPath = Path.of(clonedRepo.toString(), type.getFolderName());
         if (!fileUtils.folderExists(assetRootPath)) {
             log.warn("No {} folder found in {}", type.getDescription(), clonedRepo);
-            return List.of();
+
+            assetRootPath = Path.of(clonedRepo.toString(), type.getLegacyFolderName()); 
+            if (!fileUtils.folderExists(assetRootPath)) {
+                return List.of();
+            }
         }
 
         return createSemanticAssetPaths(assetRootPath, scanner, type.isIgnoringObsoleteVersions());

--- a/src/main/java/it/gov/innovazione/ndc/harvester/SemanticAssetType.java
+++ b/src/main/java/it/gov/innovazione/ndc/harvester/SemanticAssetType.java
@@ -5,27 +5,32 @@ import lombok.Getter;
 @Getter
 public enum SemanticAssetType {
     ONTOLOGY("ontology",
+            "assets/ontologies",
             "Ontologie",
             "http://www.w3.org/2002/07/owl#Ontology",
             true),
     CONTROLLED_VOCABULARY("controlled vocabulary",
+            "assets/vocabularies",
             "VocabolariControllati",
             "http://dati.gov.it/onto/dcatapit#Dataset",
             false),
     SCHEMA("schema",
+            "assets/schemas",
             "Schema",
             "http://dati.gov.it/onto/dcatapit#Dataset",
             false);
 
     private final String description;
     private final String folderName;
+    private final String legacyFolderName;
     private final String typeIri;
     private final boolean isIgnoringObsoleteVersions;
 
-    SemanticAssetType(String description, String folderName, String typeIri,
-                      boolean isIgnoringObsoleteVersions) {
+    SemanticAssetType(String description, String folderName, String legacyFolderName,
+                      String typeIri, boolean isIgnoringObsoleteVersions) {
         this.description = description;
         this.folderName = folderName;
+        this.legacyFolderName = legacyFolderName;
         this.typeIri = typeIri;
         this.isIgnoringObsoleteVersions = isIgnoringObsoleteVersions;
     }


### PR DESCRIPTION
## This PR

- supports `assets/` folders

## Notes

this allows processing teamdigitale/dati-semantic-cookiecutter