### PR TITLE
feat: status metadata

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.springframework.boot' version '2.7.10'
+    id 'org.springframework.boot' version '2.7.12'
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
     id 'java'
     id 'com.google.cloud.tools.jib' version '3.1.4'
@@ -63,7 +63,7 @@ dependencies {
     implementation 'io.swagger:swagger-annotations:1.5.20'
     implementation 'org.mapstruct:mapstruct:1.4.2.Final'
 
-    runtimeOnly 'mysql:mysql-connector-java:8.0.32'
+    runtimeOnly 'mysql:mysql-connector-java:8.0.33'
 
     compileOnly 'org.projectlombok:lombok'
     testCompileOnly 'org.projectlombok:lombok'

--- a/src/main/java/it/gov/innovazione/ndc/controller/exception/RestExceptionHandler.java
+++ b/src/main/java/it/gov/innovazione/ndc/controller/exception/RestExceptionHandler.java
@@ -1,7 +1,8 @@
 package it.gov.innovazione.ndc.controller.exception;
 
-import it.gov.innovazione.ndc.model.Builders;
 import it.gov.innovazione.ndc.gen.dto.Problem;
+import it.gov.innovazione.ndc.model.Builders;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -12,11 +13,13 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 
 import javax.validation.ConstraintViolationException;
 
+@Slf4j
 @ControllerAdvice
 public class RestExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler(value = {ProblemBuildingException.class})
     public ResponseEntity<Object> handleExceptionWithAppProblem(ProblemBuildingException exception) {
+        log.error("ProblemBuildingException: ", exception);
         HttpStatus status = exception.getStatus();
         Problem report = exception.buildReport();
         return buildResponseEntityForAppProblem(status, report);
@@ -24,7 +27,8 @@ public class RestExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler(value = {ConstraintViolationException.class, MethodArgumentTypeMismatchException.class })
     public ResponseEntity<Object> handleValidationFailures(RuntimeException ex) {
-        String errorMessage = "Validation for parameter failed " + ex.getMessage();
+        log.error("ValidationFailure: ", ex);
+        String errorMessage = "Validation for parameter failed";
         Problem report = Builders.problem()
                 .errorClass(ex.getClass().getSimpleName())
                 .status(HttpStatus.BAD_REQUEST)

--- a/src/main/java/it/gov/innovazione/ndc/harvester/model/BaseSemanticAssetModel.java
+++ b/src/main/java/it/gov/innovazione/ndc/harvester/model/BaseSemanticAssetModel.java
@@ -7,6 +7,7 @@ import it.gov.innovazione.ndc.harvester.model.extractors.NodeSummaryExtractor;
 import it.gov.innovazione.ndc.harvester.model.index.Distribution;
 import it.gov.innovazione.ndc.harvester.model.index.NodeSummary;
 import it.gov.innovazione.ndc.harvester.model.index.SemanticAssetMetadata;
+import it.gov.innovazione.ndc.model.profiles.Admsapit;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.Property;
 import org.apache.jena.rdf.model.Resource;
@@ -119,6 +120,7 @@ public abstract class BaseSemanticAssetModel implements SemanticAssetModel {
             .temporal(LiteralExtractor.extractOptional(mainResource, temporal))
             .conformsTo(NodeSummaryExtractor.maybeNodeSummaries(mainResource, conformsTo, FOAF.name))
             .distributions(getDistributions())
+            .status(LiteralExtractor.extractAll(mainResource, Admsapit.status))
             .build();
     }
 

--- a/src/main/java/it/gov/innovazione/ndc/harvester/model/SchemaModel.java
+++ b/src/main/java/it/gov/innovazione/ndc/harvester/model/SchemaModel.java
@@ -59,6 +59,7 @@ public class SchemaModel extends BaseSemanticAssetModel {
             .keywords(LiteralExtractor.extractAll(mainResource, keyword))
             .conformsTo(NodeSummaryExtractor.maybeNodeSummaries(mainResource, conformsTo, FOAF.name))
             .keyClasses(getKeyClasses())
+            .status(LiteralExtractor.extractAll(mainResource, Admsapit.status))
             .build();
     }
 

--- a/src/main/java/it/gov/innovazione/ndc/harvester/model/index/SemanticAssetMetadata.java
+++ b/src/main/java/it/gov/innovazione/ndc/harvester/model/index/SemanticAssetMetadata.java
@@ -37,6 +37,9 @@ public class SemanticAssetMetadata {
     @Field(type = Keyword, copyTo = "searchableText")
     private List<String> keywords;
 
+    @Field(type = Keyword)
+    private List<String> status;
+
     @Field(type = Date)
     private LocalDate modifiedOn;
     @Field(type = Keyword)

--- a/src/main/java/it/gov/innovazione/ndc/model/profiles/Admsapit.java
+++ b/src/main/java/it/gov/innovazione/ndc/model/profiles/Admsapit.java
@@ -10,4 +10,5 @@ public class Admsapit {
     public static final Property semanticAssetInUse = createProperty(NS + "semanticAssetInUse");
     public static final Property prefix = createProperty(NS + "prefix");
     public static final Property project = createProperty(NS + "Project");
+    public static final Property status = createProperty(NS + "status");
 }

--- a/src/main/resources/public/api-docs.yaml
+++ b/src/main/resources/public/api-docs.yaml
@@ -401,6 +401,11 @@ components:
           maxItems: *max-array-size-default
         rightsHolder:
           $ref: "#/components/schemas/NodeSummary"
+        status:
+          type: array
+          uniqueItems: true
+          items:
+            type: string
     SemanticAssetDetails:
       allOf:
         - $ref: "#/components/schemas/SearchResultItem"

--- a/src/test/java/it/gov/innovazione/ndc/harvester/model/BaseSemanticAssetModelTest.java
+++ b/src/test/java/it/gov/innovazione/ndc/harvester/model/BaseSemanticAssetModelTest.java
@@ -1,25 +1,5 @@
 package it.gov.innovazione.ndc.harvester.model;
 
-import it.gov.innovazione.ndc.harvester.model.index.Distribution;
-import it.gov.innovazione.ndc.harvester.model.index.NodeSummary;
-import it.gov.innovazione.ndc.harvester.model.index.SemanticAssetMetadata;
-import it.gov.innovazione.ndc.harvester.model.exception.InvalidModelException;
-import it.gov.innovazione.ndc.model.profiles.EuropePublicationVocabulary;
-import it.gov.innovazione.ndc.model.profiles.NDC;
-import org.apache.jena.rdf.model.Model;
-import org.apache.jena.rdf.model.Property;
-import org.apache.jena.rdf.model.RDFNode;
-import org.apache.jena.rdf.model.Statement;
-import org.apache.jena.sparql.vocabulary.FOAF;
-import org.apache.jena.vocabulary.DCAT;
-import org.apache.jena.vocabulary.RDF;
-import org.apache.jena.vocabulary.VCARD4;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
-import java.time.LocalDate;
-import java.util.List;
-
 import static it.gov.innovazione.ndc.harvester.SemanticAssetType.CONTROLLED_VOCABULARY;
 import static org.apache.jena.rdf.model.ModelFactory.createDefaultModel;
 import static org.apache.jena.rdf.model.ResourceFactory.createLangLiteral;
@@ -47,6 +27,27 @@ import static org.apache.jena.vocabulary.DCTerms.title;
 import static org.apache.jena.vocabulary.OWL.versionInfo;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Property;
+import org.apache.jena.rdf.model.RDFNode;
+import org.apache.jena.rdf.model.Statement;
+import org.apache.jena.sparql.vocabulary.FOAF;
+import org.apache.jena.vocabulary.RDF;
+import org.apache.jena.vocabulary.VCARD4;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import it.gov.innovazione.ndc.harvester.model.exception.InvalidModelException;
+import it.gov.innovazione.ndc.harvester.model.index.Distribution;
+import it.gov.innovazione.ndc.harvester.model.index.NodeSummary;
+import it.gov.innovazione.ndc.harvester.model.index.SemanticAssetMetadata;
+import it.gov.innovazione.ndc.model.profiles.Admsapit;
+import it.gov.innovazione.ndc.model.profiles.EuropePublicationVocabulary;
+import it.gov.innovazione.ndc.model.profiles.NDC;
 
 class BaseSemanticAssetModelTest {
 
@@ -103,7 +104,9 @@ class BaseSemanticAssetModelTest {
                 .addProperty(format, EuropePublicationVocabulary.FILE_TYPE_JSON)
                 .addProperty(accessURL, jenaModel.createResource(CV_IRI + "/dist/json"))
                 .addProperty(downloadURL, jenaModel.createResource(CV_IRI + "/dist/json/test.json"))
-            );
+            ) 
+            .addProperty(Admsapit.status, "catalogued")
+            .addProperty(Admsapit.status, "published");
         semanticAssetModel = new TestBaseSemanticAssetModel(jenaModel, TTL_FILE, "some-repo");
     }
 
@@ -412,6 +415,21 @@ class BaseSemanticAssetModelTest {
         SemanticAssetMetadata metadata = semanticAssetModel.extractMetadata();
 
         assertThat(metadata.getTemporal()).isNull();
+    }
+    
+    @Test
+    void shouldExtractMetadataWithStatus() {
+        SemanticAssetMetadata metadata = semanticAssetModel.extractMetadata();
+
+        assertThat(metadata.getStatus()).containsExactlyInAnyOrder("catalogued", "published");
+    }
+
+    @Test
+    void shouldExtractMetadataWithOutStatus() {
+        jenaModel.getResource(CV_IRI).removeAll(Admsapit.status);
+        SemanticAssetMetadata metadata = semanticAssetModel.extractMetadata();
+
+        assertThat(metadata.getStatus()).isEmpty();
     }
 
     private void removeAllPropertyStatements(Property property) {

--- a/src/test/java/it/gov/innovazione/ndc/harvester/model/SchemaModelTest.java
+++ b/src/test/java/it/gov/innovazione/ndc/harvester/model/SchemaModelTest.java
@@ -92,7 +92,9 @@ public class SchemaModelTest {
             .addProperty(Admsapit.hasKeyClass,
                 jenaModel.createResource("http://keyClasses1").addProperty(label, "keyClasses1"))
             .addProperty(Admsapit.hasKeyClass,
-                jenaModel.createResource("http://keyClasses2").addProperty(label, "keyClasses2"));
+                jenaModel.createResource("http://keyClasses2").addProperty(label, "keyClasses2"))
+            .addProperty(Admsapit.status, "catalogued")
+            .addProperty(Admsapit.status, "published");;
     }
 
     @Test
@@ -321,5 +323,22 @@ public class SchemaModelTest {
         SemanticAssetMetadata metadata = model.extractMetadata();
 
         assertThat(metadata.getKeyClasses()).isEmpty();
+    }
+
+    @Test
+    void shouldExtractMetadataWithStatus() {
+        SchemaModel model = new SchemaModel(jenaModel, TTL_FILE, REPO_URL);
+        SemanticAssetMetadata metadata = model.extractMetadata();
+
+        assertThat(metadata.getStatus()).containsExactlyInAnyOrder("catalogued", "published");
+    }
+
+    @Test
+    void shouldExtractMetadataWithOutStatus() {
+        jenaModel.getResource(SCHEMA_IRI).removeAll(Admsapit.status);
+        SchemaModel model = new SchemaModel(jenaModel, TTL_FILE, REPO_URL);
+        SemanticAssetMetadata metadata = model.extractMetadata();
+
+        assertThat(metadata.getStatus()).isEmpty();
     }
 }


### PR DESCRIPTION
This PR:

- adds a `status` field to `SemanticAssetMetadata`
- upgrades Spring and MySQL versions to address issues raised in OWASP security check
- avoid disclosing tech stack when exceptions are thrown

@CreaIstat 