### PR TITLE
various fixes

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -25,7 +25,7 @@ services:
   mysql:
     image: mysql
     command: --mysql-native-password=ON
-    restart: always
+    restart: no
     ports:
       - 3306:3306
     environment:
@@ -34,7 +34,7 @@ services:
 
   backend:
     image: gcr.io/distroless/java:11-debug-nonroot
-    restart: on-failure
+    restart: no
     depends_on:
       - virtuoso
       - mysql

--- a/src/main/java/it/gov/innovazione/ndc/alerter/AlerterService.java
+++ b/src/main/java/it/gov/innovazione/ndc/alerter/AlerterService.java
@@ -4,10 +4,13 @@ import it.gov.innovazione.ndc.alerter.data.EventService;
 import it.gov.innovazione.ndc.alerter.dto.EventDto;
 import it.gov.innovazione.ndc.alerter.event.AlertableEvent;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
+import java.security.Principal;
 import java.time.Instant;
+import java.util.Optional;
 
 import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
 
@@ -30,8 +33,10 @@ public class AlerterService {
     }
 
     private String getUser() {
-        return defaultIfNull(SecurityContextHolder.getContext().getAuthentication().getName(), "system");
-
+        return Optional.of(SecurityContextHolder.getContext())
+                .map(SecurityContext::getAuthentication)
+                .map(Principal::getName)
+                .orElse("system");
     }
 
 }

--- a/src/main/java/it/gov/innovazione/ndc/alerter/data/EntityService.java
+++ b/src/main/java/it/gov/innovazione/ndc/alerter/data/EntityService.java
@@ -58,7 +58,12 @@ public abstract class EntityService<T extends Nameable, D extends Nameable> {
             throw new ConflictingOperationException(getEntityName() + " id must not be null for update operation");
         }
         assertExistsById(dto.getId());
+        beforeUpdate(dto);
         return toDto(getRepository().save(getEntityMapper().toEntity(dto)));
+    }
+
+    protected void beforeUpdate(D dto) {
+
     }
 
     private void assertExistsById(String id) {
@@ -69,9 +74,14 @@ public abstract class EntityService<T extends Nameable, D extends Nameable> {
 
     public D delete(String id) {
         T entity = getEntityById(id);
+        beforeDelete(entity);
         D dto = toDto(entity);
         getRepository().delete(entity);
         return dto;
+    }
+
+    protected void beforeDelete(T entity) {
+
     }
 
     public D getById(String id) {

--- a/src/main/java/it/gov/innovazione/ndc/alerter/data/ProfileInitializer.java
+++ b/src/main/java/it/gov/innovazione/ndc/alerter/data/ProfileInitializer.java
@@ -8,6 +8,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.stereotype.Service;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -38,11 +39,21 @@ public class ProfileInitializer implements Initializer {
                         .eventCategories(pair.getRight())
                         .minSeverity(Severity.INFO)
                         .aggregationTime(60L)
+                        .lastAlertedAt(Instant.now())
                         .build())
                 .forEach(p -> {
                     log.info("Creating default profile: {}", p.getName());
                     repository.save(p);
                 });
+    }
 
+    private List<String> getUnmodifiableProfileNames() {
+        return DEFAULT_PROFILES.stream()
+                .map(Pair::getLeft)
+                .collect(Collectors.toList());
+    }
+
+    public boolean isProfileNameUnmodifiable(String name) {
+        return getUnmodifiableProfileNames().contains(name);
     }
 }

--- a/src/main/java/it/gov/innovazione/ndc/eventhandler/event/HarvesterFinishedEvent.java
+++ b/src/main/java/it/gov/innovazione/ndc/eventhandler/event/HarvesterFinishedEvent.java
@@ -9,6 +9,7 @@ import lombok.Builder;
 import lombok.Data;
 
 import java.util.Map;
+import java.util.Optional;
 
 @Builder
 @Data
@@ -36,7 +37,7 @@ public class HarvesterFinishedEvent implements AlertableEvent {
 
     @Override
     public Severity getSeverity() {
-        if (status == HarvesterRun.Status.ALREADY_RUNNING) {
+        if (status == HarvesterRun.Status.ALREADY_RUNNING || status == HarvesterRun.Status.NDC_ISSUES_PRESENT) {
             return Severity.WARNING;
         } else if (status == HarvesterRun.Status.SUCCESS || status == HarvesterRun.Status.UNCHANGED) {
             return Severity.INFO;
@@ -53,7 +54,7 @@ public class HarvesterFinishedEvent implements AlertableEvent {
                 "repository", repository,
                 "revision", revision,
                 "status", status,
-                "exception", exception
+                "exception", Optional.ofNullable(exception).map(Exception::getMessage).orElse("")
         );
     }
 }

--- a/src/main/java/it/gov/innovazione/ndc/eventhandler/handler/AlerterEnabledEventListener.java
+++ b/src/main/java/it/gov/innovazione/ndc/eventhandler/handler/AlerterEnabledEventListener.java
@@ -39,9 +39,9 @@ public class AlerterEnabledEventListener implements NdcEventHandler {
         if (Objects.isNull(payload) || Objects.isNull(payload.getChanges())) {
             return;
         }
-        if (payload.isChange(ConfigKey.ALERTER_ENABLED, Boolean.TRUE)) {
+        if (payload.isChange(ConfigKey.ALERTER_ENABLED, Boolean.TRUE, Boolean.FALSE)) {
             log.info("Alerter enabled, setting all profiles last updated");
-            profileService.setAllLastUpdated(backoff);
+            profileService.setAllLastAlertedAt(backoff);
         }
     }
 }

--- a/src/main/java/it/gov/innovazione/ndc/harvester/service/ActualConfigService.java
+++ b/src/main/java/it/gov/innovazione/ndc/harvester/service/ActualConfigService.java
@@ -21,6 +21,9 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.apache.commons.lang3.StringUtils.equalsIgnoreCase;
+import static org.apache.commons.lang3.StringUtils.trim;
+
 @Service
 @RequiredArgsConstructor
 @Slf4j
@@ -286,7 +289,7 @@ public class ActualConfigService extends ConfigService {
         public Predicate<String> getValidator() {
             return s -> {
                 try {
-                    parser.parser.apply(s);
+                    parser.parsingFunction.apply(s);
                     return true;
                 } catch (Exception e) {
                     return false;
@@ -299,7 +302,14 @@ public class ActualConfigService extends ConfigService {
     @RequiredArgsConstructor
     public enum Parser {
         TO_LONG(Long::parseLong),
-        TO_BOOLEAN(Boolean::parseBoolean);
-        private final Function<String, Object> parser;
+        TO_BOOLEAN(Parser::parseBoolean);
+        private final Function<String, Object> parsingFunction;
+
+        private static Boolean parseBoolean(String s) {
+            if (!equalsIgnoreCase(trim(s), "true") && !equalsIgnoreCase(trim(s), "false")) {
+                throw new IllegalArgumentException("Value must be 'true' or 'false'");
+            }
+            return Boolean.parseBoolean(trim(s));
+        }
     }    
 }

--- a/src/test/java/it/gov/innovazione/ndc/harvester/service/ActualConfigServiceTest.java
+++ b/src/test/java/it/gov/innovazione/ndc/harvester/service/ActualConfigServiceTest.java
@@ -1,0 +1,58 @@
+package it.gov.innovazione.ndc.harvester.service;
+
+import co.elastic.clients.util.Pair;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static it.gov.innovazione.ndc.harvester.service.ActualConfigService.Parser.TO_BOOLEAN;
+import static it.gov.innovazione.ndc.harvester.service.ActualConfigService.Parser.TO_LONG;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ActualConfigServiceTest {
+
+    static Stream<Arguments> provideValidValues() {
+        return Stream.of(
+                Arguments.of(TO_BOOLEAN, "true", true),
+                Arguments.of(TO_BOOLEAN, " false", false),
+                Arguments.of(TO_BOOLEAN, "True", true),
+                Arguments.of(TO_BOOLEAN, "False", false),
+                Arguments.of(TO_BOOLEAN, "tRuE", true),
+                Arguments.of(TO_BOOLEAN, "fAlSe", false),
+                Arguments.of(TO_LONG, "1", 1L),
+                Arguments.of(TO_LONG, "0", 0L),
+                Arguments.of(TO_LONG, "100", 100L));
+    }
+
+    static Stream<Arguments> provideInvalidValues() {
+        return Stream.of(
+                        Pair.of(TO_BOOLEAN, "invalid"),
+                        Pair.of(TO_BOOLEAN, "1"),
+                        Pair.of(TO_BOOLEAN, "0"),
+                        Pair.of(TO_BOOLEAN, "yes"),
+                        Pair.of(TO_BOOLEAN, "no"),
+                        Pair.of(TO_BOOLEAN, null),
+                        Pair.of(TO_LONG, "invalid"),
+                        Pair.of(TO_LONG, "true"),
+                        Pair.of(TO_LONG, "false"),
+                        Pair.of(TO_LONG, "yes"),
+                        Pair.of(TO_LONG, "no"))
+                .map(parserPair -> Arguments.of(parserPair.key(), parserPair.value()));
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideValidValues")
+    void testParseTrue(ActualConfigService.Parser parser, String validString, Object expectedValue) {
+        assertEquals(expectedValue, parser.getParsingFunction().apply(validString));
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideInvalidValues")
+    void testParseNull(ActualConfigService.Parser parser, String invalidValue) {
+        assertThrows(IllegalArgumentException.class, () -> parser.getParsingFunction().apply(invalidValue));
+    }
+
+}


### PR DESCRIPTION
fixes: 

- boolean config validator
- set last alerted for all profiles when enabling alerter
- skips events that are too old (based on property alerter.aggregation-time-multiplier:50 * aggregationTime)
- updates profile lastAlertedAt even if profile has no recipients
- changes "errori" into "eventi" in the mail body
- fixes a nullpointerexception when getting user from context
- alert for changed configuration/repository values
- disable autorestart of docker containers (for local dev)
- default profiles are created (if needed) with lastAlertedAt using current timestamp
- disallow deletion of default profiles
- disallow updating the name of default profiles