### PR TITLE
feat: paginate harvest runs endpoint and add old runs cleanup job

### DIFF
--- a/src/main/java/it/gov/innovazione/ndc/controller/HarvestJobController.java
+++ b/src/main/java/it/gov/innovazione/ndc/controller/HarvestJobController.java
@@ -9,7 +9,7 @@ import it.gov.innovazione.ndc.harvester.HarvesterJob;
 import it.gov.innovazione.ndc.harvester.HarvesterService;
 import it.gov.innovazione.ndc.harvester.JobExecutionResponse;
 import it.gov.innovazione.ndc.harvester.service.HarvesterRunService;
-import it.gov.innovazione.ndc.model.harvester.HarvesterRun;
+import it.gov.innovazione.ndc.model.harvester.HarvesterRunResult;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -60,10 +60,12 @@ public class HarvestJobController {
     @GetMapping("jobs/harvest/run")
     @Operation(
             operationId = "getHarvestRuns",
-            description = "Get all harvest runs",
-            summary = "Get all harvest runs")
-    public List<HarvesterRun> getAllRuns() {
-        return harvesterRunService.getAllRuns();
+            description = "Get harvest runs with pagination",
+            summary = "Get harvest runs with pagination")
+    public HarvesterRunResult getAllRuns(
+            @RequestParam(required = false, defaultValue = "0") Integer offset,
+            @RequestParam(required = false, defaultValue = "20") Integer limit) {
+        return harvesterRunService.getRunsPaginated(offset, limit);
     }
 
     @GetMapping("jobs/harvest/running")

--- a/src/main/java/it/gov/innovazione/ndc/harvester/service/HarvesterRunService.java
+++ b/src/main/java/it/gov/innovazione/ndc/harvester/service/HarvesterRunService.java
@@ -8,6 +8,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
 
+import it.gov.innovazione.ndc.model.harvester.HarvesterRunResult;
+
 import java.sql.ResultSet;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -132,6 +134,37 @@ public class HarvesterRunService {
                 .filter(harvesterRun -> isMoreRecentThan(harvesterRun, days));
     }
 
+    public HarvesterRunResult getRunsPaginated(int offset, int limit) {
+        Integer totalCount = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM HARVESTER_RUN", Integer.class);
+
+        String sqlQuery = "SELECT "
+                + "ID, "
+                + "CORRELATION_ID, "
+                + "REPOSITORY_ID, "
+                + "REPOSITORY_URL, "
+                + "INSTANCE, "
+                + "REVISION, "
+                + "REVISION_COMMITTED_AT, "
+                + "STARTED, "
+                + "STARTED_BY, "
+                + "FINISHED, "
+                + "STATUS, "
+                + "REASON, "
+                + "CONFORMANCE_REPORT "
+                + "FROM HARVESTER_RUN "
+                + "ORDER BY STARTED DESC "
+                + "LIMIT ? OFFSET ?";
+        List<HarvesterRun> data = jdbcTemplate.query(sqlQuery, (rs, rowNum) -> mapRow(rs), limit, offset);
+
+        return HarvesterRunResult.builder()
+                .totalCount(totalCount != null ? totalCount : 0)
+                .limit(limit)
+                .offset(offset)
+                .data(data)
+                .build();
+    }
+
     public List<HarvesterRun> getAllRuns() {
         String sqlQuery = "SELECT "
                 + "ID, "
@@ -149,22 +182,29 @@ public class HarvesterRunService {
                 + "CONFORMANCE_REPORT "
                 + "FROM HARVESTER_RUN "
                 + "ORDER BY STARTED DESC";
-        return jdbcTemplate.query(sqlQuery, (rs, rowNum) ->
-                HarvesterRun.builder()
-                        .id(rs.getString("ID"))
-                        .correlationId(rs.getString("CORRELATION_ID"))
-                        .repositoryId(rs.getString("REPOSITORY_ID"))
-                        .repositoryUrl(rs.getString("REPOSITORY_URL"))
-                        .instance(rs.getString("INSTANCE"))
-                        .revision(rs.getString("REVISION"))
-                        .revisionCommittedAt(getInstant(rs, "REVISION_COMMITTED_AT"))
-                        .startedAt(getInstant(rs, "STARTED"))
-                        .startedBy(rs.getString("STARTED_BY"))
-                        .endedAt(getInstant(rs, "FINISHED"))
-                        .status(getStatusSafely(rs))
-                        .reason(rs.getString("REASON"))
-                        .conformanceReport(rs.getString("CONFORMANCE_REPORT"))
-                        .build());
+        return jdbcTemplate.query(sqlQuery, (rs, rowNum) -> mapRow(rs));
+    }
+
+    private HarvesterRun mapRow(ResultSet rs) {
+        try {
+            return HarvesterRun.builder()
+                    .id(rs.getString("ID"))
+                    .correlationId(rs.getString("CORRELATION_ID"))
+                    .repositoryId(rs.getString("REPOSITORY_ID"))
+                    .repositoryUrl(rs.getString("REPOSITORY_URL"))
+                    .instance(rs.getString("INSTANCE"))
+                    .revision(rs.getString("REVISION"))
+                    .revisionCommittedAt(getInstant(rs, "REVISION_COMMITTED_AT"))
+                    .startedAt(getInstant(rs, "STARTED"))
+                    .startedBy(rs.getString("STARTED_BY"))
+                    .endedAt(getInstant(rs, "FINISHED"))
+                    .status(getStatusSafely(rs))
+                    .reason(rs.getString("REASON"))
+                    .conformanceReport(rs.getString("CONFORMANCE_REPORT"))
+                    .build();
+        } catch (Exception e) {
+            throw new RuntimeException("Error mapping HarvesterRun row", e);
+        }
     }
 
     private HarvesterRun.Status getStatusSafely(ResultSet rs) {
@@ -203,6 +243,11 @@ public class HarvesterRunService {
                 && contains(threadName, harvesterRun.getRevision())
                 && contains(threadName, harvesterRun.getId())
                 && endsWithIgnoreCase(threadName, "RUNNING");
+    }
+
+    public long deleteRunsOlderThan(Instant threshold) {
+        String query = "DELETE FROM HARVESTER_RUN WHERE STARTED < ? AND STATUS <> 'RUNNING'";
+        return jdbcTemplate.update(query, java.sql.Timestamp.from(threshold));
     }
 
     private void delete(HarvesterRun harvesterRun) {

--- a/src/main/java/it/gov/innovazione/ndc/model/harvester/HarvesterRunResult.java
+++ b/src/main/java/it/gov/innovazione/ndc/model/harvester/HarvesterRunResult.java
@@ -1,0 +1,15 @@
+package it.gov.innovazione.ndc.model.harvester;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@Builder
+public class HarvesterRunResult {
+    private final int totalCount;
+    private final int limit;
+    private final int offset;
+    private final List<HarvesterRun> data;
+}

--- a/src/main/java/it/gov/innovazione/ndc/service/HarvesterRunCleaner.java
+++ b/src/main/java/it/gov/innovazione/ndc/service/HarvesterRunCleaner.java
@@ -1,0 +1,30 @@
+package it.gov.innovazione.ndc.service;
+
+import it.gov.innovazione.ndc.harvester.service.HarvesterRunService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.time.Period;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class HarvesterRunCleaner {
+
+    private final HarvesterRunService harvesterRunService;
+    @Value("${harvester.run-cleaner.retention:P120D}")
+    private Period retention;
+
+    // schedule each day at 01:00
+    @Scheduled(cron = "${harvester.run-cleaner.cron:0 0 1 * * *}")
+    void cleanOldRuns() {
+        Instant threshold = Instant.now().minus(retention);
+        log.info("Cleaning harvester runs older than {} days", retention.getDays());
+        long count = harvesterRunService.deleteRunsOlderThan(threshold);
+        log.info("Deleted {} harvester runs older than {}", count, threshold);
+    }
+}


### PR DESCRIPTION
## Summary
- **Paginated `/jobs/harvest/run`**: the GET endpoint now accepts `offset` (default 0) and `limit` (default 20) query params, returning a `{ totalCount, limit, offset, data }` response instead of an unbounded list. The SQL query uses `LIMIT/OFFSET` and `COUNT(*)` to avoid loading all rows in memory.
- **Scheduled cleanup of old runs**: new `HarvesterRunCleaner` component deletes harvester runs older than a configurable retention period (default 120 days, property `harvester.run-cleaner.retention`). Runs daily at 01:00 (configurable via `harvester.run-cleaner.cron`). Runs with status `RUNNING` are never deleted.
- **Refactored row mapper**: extracted shared `mapRow()` method in `HarvesterRunService` to avoid duplication between paginated and full queries.

## Test plan
- [ ] Verify `GET /jobs/harvest/run` returns paginated response with default `offset=0` and `limit=20`
- [ ] Verify `GET /jobs/harvest/run?offset=10&limit=5` returns correct slice
- [ ] Verify `totalCount` reflects the actual number of rows in `HARVESTER_RUN`
- [ ] Verify the cleanup job runs on schedule and deletes only non-RUNNING rows older than retention
- [ ] Verify existing consumers of the endpoint are updated to handle the new response format