### PR TITLE
fix(dashboard): stats view considera solo run SUCCESS

### DIFF
--- a/src/main/resources/db/migration/V16__fix_latest_harvester_run_view_success_only.sql
+++ b/src/main/resources/db/migration/V16__fix_latest_harvester_run_view_success_only.sql
@@ -1,0 +1,22 @@
+-- The dashboard stats endpoint joins SEMANTIC_CONTENT_STATS to the "latest harvester run
+-- of the year" per repository via LATEST_HARVESTER_RUN_BY_YEAR. The previous definition
+-- picked the latest run regardless of status: a run ending UNCHANGED (or FAILURE, RUNNING,
+-- NDC_ISSUES_PRESENT) writes no SEMANTIC_CONTENT_STATS rows, yet became the latest run of
+-- the year and thus shadowed the last successful run, blanking the whole dashboard to 0.
+-- Only SUCCESS runs reach harvest()/saveStats() and therefore write content stats (see
+-- DashboardRepo / GET_ALL_STATS_QUERY, which already filter on STATUS = 'SUCCESS'), so
+-- restrict the view to them.
+CREATE OR REPLACE VIEW LATEST_HARVESTER_RUN_BY_YEAR AS
+WITH LATEST_RUN_BY_YEAR AS (SELECT REPOSITORY_ID,
+                                   YEAR(STARTED) AS YEAR,
+                                   MAX(STARTED)  AS LATEST_STARTED
+                            FROM HARVESTER_RUN
+                            WHERE STATUS = 'SUCCESS'
+                            GROUP BY REPOSITORY_ID, YEAR(STARTED))
+SELECT HR.*
+FROM HARVESTER_RUN HR
+         JOIN LATEST_RUN_BY_YEAR LRBY
+              ON HR.REPOSITORY_ID = LRBY.REPOSITORY_ID
+                  AND YEAR(HR.STARTED) = LRBY.YEAR
+                  AND HR.STARTED = LRBY.LATEST_STARTED
+WHERE HR.STATUS = 'SUCCESS';


### PR DESCRIPTION
## Problema

Gli endpoint dashboard (`/api/semantic-assets/stats`, `/api/dashboard/aggregated-*`) leggono le statistiche unendo `SEMANTIC_CONTENT_STATS` all'"ultimo run dell'anno per repository" tramite la view `LATEST_HARVESTER_RUN_BY_YEAR`.

La view selezionava l'ultimo run per `MAX(STARTED)` **senza filtro sullo stato**. Ma solo i run `SUCCESS` arrivano a `harvest()`/`saveStats()` e scrivono righe in `SEMANTIC_CONTENT_STATS`; un run `UNCHANGED` (harvest a vuoto, tipico dopo un deploy o negli harvest schedulati quando i repo non sono cambiati) — così come `FAILURE`, `RUNNING`, `NDC_ISSUES_PRESENT` — **non scrive alcuna riga di stats** ma diventava comunque il run più recente dell'anno.

Risultato: l'ultimo run a vuoto **oscurava** l'ultimo run `SUCCESS`, la JOIN non trovava righe e **la dashboard andava a 0** pur avendo i dati ancora in tabella. La search (Elasticsearch) restava intatta → sintomo classico "i contenuti si vedono ma i numeri sono a 0".

## Fix

La view considera solo i run `STATUS = 'SUCCESS'`, coerentemente con `DashboardRepo`/`GET_ALL_STATS_QUERY` che già filtrano su SUCCESS. Nuova migration `V16`, nessuna modifica applicativa.

## Verifica

Riprodotto in prod: harvest `force=false` → 10 repo `UNCHANGED` → `stats?year=2026` da 408 a 0. Con la view filtrata su SUCCESS il run a vuoto non maschera più l'ultimo SUCCESS.